### PR TITLE
Add ability to run mass retirement once a day

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,5 +3,6 @@
     "Retirement Tag": "Retired",
     "Mass Retirement on Startup" :  "off",
     "Real-time Notifications" :  "off",
-    "Mass Retirement Notifications" : "on"
+    "Mass Retirement Notifications" : "on",
+    "Last Mass Retirement" : 0
 }


### PR DESCRIPTION
I have verified that this pull request:

* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. Fixes #6

If the user checks "Once Daily" for mass retirement, then on every profile load, the addon checks to see if at least a day has passed since mass retirement has ran.

It's tedious to test this feature, but to do so, keep on going to Tools > Addons > MIA Retirement Addon > Config and changing "Last Mass Retirement" to 0 (so that the addon thinks it has been a long time since the last mass retirement).