### PR TITLE
Add mass retirement timer

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -160,6 +160,7 @@ def getProgressWidget():
     return progressWidget, bar;
 
 def applyRetirementActions(notes = False, showNotification = True):
+    timeStart = time.time() / 1000
     notesToDelete = []
     cardsToMove = []
     suspended = 0
@@ -198,9 +199,10 @@ def applyRetirementActions(notes = False, showNotification = True):
         moveToDeck(cardsToMove)
     if ndl > 0:
         notification +='- '+  str(ndl) + ' note(s) have been deleted<br>'
-        mw.col.remNotes(notesToDelete)   
+        mw.col.remNotes(notesToDelete)
+    timeEnd = time.time() / 1000   
     if notification != '' and RetroNotifications:
-        mia('<b>'+ str(total) + ' card(s) have been retired:</b><br>' + notification)
+        mia('<b>'+ str(total) + ' card(s) have been retired in ' + str(round(timeEnd - timeStart, 5)) + ' seconds:</b><br>' + notification)
     mw.reset()
     saveMassRetirementTimestamp(time.time())
 

--- a/src/main.py
+++ b/src/main.py
@@ -160,7 +160,7 @@ def getProgressWidget():
     return progressWidget, bar;
 
 def applyRetirementActions(notes = False, showNotification = True):
-    timeStart = time.time() / 1000
+    timeStart = time.time()
     notesToDelete = []
     cardsToMove = []
     suspended = 0
@@ -200,9 +200,9 @@ def applyRetirementActions(notes = False, showNotification = True):
     if ndl > 0:
         notification +='- '+  str(ndl) + ' note(s) have been deleted<br>'
         mw.col.remNotes(notesToDelete)
-    timeEnd = time.time() / 1000   
+    timeEnd = time.time()  
     if notification != '' and RetroNotifications:
-        mia('<b>'+ str(total) + ' card(s) have been retired in ' + str(round(timeEnd - timeStart, 5)) + ' seconds:</b><br>' + notification)
+        mia('<b>'+ str(total) + ' card(s) have been retired in ' + str(round(timeEnd - timeStart, 3)) + ' seconds:</b><br>' + notification)
     mw.reset()
     saveMassRetirementTimestamp(time.time())
 


### PR DESCRIPTION
This adds a timer to mass retirement. The addon is already so fast that most timers don't reach over a few seconds, but that's okay.

I have verified that this pull request:

* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
